### PR TITLE
Import user add strip and downcase

### DIFF
--- a/import_users/import_users.rb
+++ b/import_users/import_users.rb
@@ -61,6 +61,7 @@ class PagerDutyAgent
       :user => {
         :name => name,
         :email => email,
+        # .downcase and strip to handle inconsistencies in the .csv
         :role => role.downcase.strip,
         :job_title => title
       }

--- a/import_users/import_users.rb
+++ b/import_users/import_users.rb
@@ -61,7 +61,6 @@ class PagerDutyAgent
       :user => {
         :name => name,
         :email => email,
-        # .downcase and strip to handle inconsistencies in the .csv
         :role => role.downcase.strip,
         :job_title => title
       }

--- a/import_users/import_users.rb
+++ b/import_users/import_users.rb
@@ -61,7 +61,7 @@ class PagerDutyAgent
       :user => {
         :name => name,
         :email => email,
-        :role => role,
+        :role => role.downcase.strip,
         :job_title => title
       }
     }


### PR DESCRIPTION
When Support receives user import csv's from Success, they're not always formatting correctly for the API. I added `.downcase` and `.strip` in case we get "Admin " instead of "admin".

I have tested this one case ("Admin ") and it worked.