### PR TITLE
Fixes misnamed variable - e doesn't exist - outputs the error instead

### DIFF
--- a/overrides_bulk_operations/vacation_overrides.py
+++ b/overrides_bulk_operations/vacation_overrides.py
@@ -73,7 +73,7 @@ def create_overrides():
             }}
         )
         if not create_response.ok:
-            message = "HTTP error: %d"%e.response.status_code
+            message = "HTTP error: %d" % create_response.status_code
             print("Error creating override; "+message)
             continue
         print("Success.")


### PR DESCRIPTION
Currently vacation_overrides.py fails on receiving a non ok response code due to e not existing as a variable.
