### PR TITLE
DOGE-337: User Deprovision Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.DS_Store
 *.csv
 .idea
+backup/
+logs/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 *.DS_Store
 *.csv
+.idea

--- a/user_deprovision/README.md
+++ b/user_deprovision/README.md
@@ -10,22 +10,22 @@ This script is meant to be used as a command line tool with the following argume
 
 `./user_deprovision.py --access-token ENTER_PD_ACCESS_TOKEN --users-emails-from-csv ./emails-to-remove.csv --from-email user-requesting-deletion@example.com`
 
-**`-a`**, **`--access-token`**: A valid PagerDuty v2 REST API access token from your account
+`-a`, `--access-token`: A valid PagerDuty v2 REST API access token from your account
 
-**`-u`**, **`--users-emails-from-csv`**: A csv file of the PagerDuty email address(es) for the user(s) you want to delete from your account
+`-u`, `--users-emails-from-csv`: A csv file of the PagerDuty email address(es) for the user(s) you want to delete from your account
 
-**`-f`**, **`--from-header`**: The PagerDuty email address of the user that is requesting the deletion
+`-f`, `--from-header`: The PagerDuty email address of the user that is requesting the deletion
 
 ### Optional arguments
 
-**`-v`**, **`--verbose`**: output the logs to the console while running
+`-v`, `--verbose`: output the logs to the console while running
 
-**`-b`**., **`--backup`**: backup info about each user to a json file
+`-b`., `--backup`: backup info about each user to a json file
 
-**`-y`**, **`--yes-to-all`**: by default the script will ask you before deleting _each user_, which can be tedious for 
+`-y`, `--delete-yes-to-all`: by default the script will ask you before deleting _each user_, which can be tedious for 
 large data sets.
 
-**`-r`**, **`-auto-resolve-incidents`**: when the script encounters a user that has open incidents, it will pause and 
+`-r`, `-auto-resolve-incidents`: when the script encounters a user that has open incidents, it will pause and 
 ask if you'd like to resolve those incidents. Even if you select `yes`, the script will not resolve incidents that have
 responders other than the user to be deleted. 
 

--- a/user_deprovision/README.md
+++ b/user_deprovision/README.md
@@ -26,10 +26,12 @@ This script is meant to be used as a command line tool with the following argume
 large data sets.
 
 `-r`, `-auto-resolve-incidents`: when the script encounters a user that has open incidents, it will pause and 
-ask if you'd like to resolve those incidents. Even if you select `yes`, the script will not resolve incidents that have
-responders other than the user to be deleted. 
+ask if you'd like to resolve those incidents. If you do not resolve all incidents associated with a user, the user will
+not be successfully deleted. 
 
 ## Notes and Caveats
+
+**If you do not resolve all incidents associated with a user, the user will not be successfully deleted.**
 
 You might see a 400 error when removing a user from the team, but this error itself is sometimes erroneous. If the log output shows that the user wasn't successfully removed from the team, but was successfully deleted, you can trust the latter information and ignore the former. 
 

--- a/user_deprovision/README.md
+++ b/user_deprovision/README.md
@@ -10,11 +10,24 @@ This script is meant to be used as a command line tool with the following argume
 
 `./user_deprovision.py --access-token ENTER_PD_ACCESS_TOKEN --users-emails-from-csv ./emails-to-remove.csv --from-email user-requesting-deletion@example.com`
 
-**-a**, **--access-token**: A valid PagerDuty v2 REST API access token from your account
+**`-a`**, **`--access-token`**: A valid PagerDuty v2 REST API access token from your account
 
-**-u**, **--users-emails-from-csv**: A csv file of the PagerDuty email address(es) for the user(s) you want to delete from your account
+**`-u`**, **`--users-emails-from-csv`**: A csv file of the PagerDuty email address(es) for the user(s) you want to delete from your account
 
-**-f**, **--from-header**: The PagerDuty email address of the user that is requesting the deletion
+**`-f`**, **`--from-header`**: The PagerDuty email address of the user that is requesting the deletion
+
+### Optional arguments
+
+**`-v`**, **`--verbose`**: output the logs to the console while running
+
+**`-b`**., **`--backup`**: backup info about each user to a json file
+
+**`-y`**, **`--yes-to-all`**: by default the script will ask you before deleting _each user_, which can be tedious for 
+large data sets.
+
+**`-r`**, **`-auto-resolve-incidents`**: when the script encounters a user that has open incidents, it will pause and 
+ask if you'd like to resolve those incidents. Even if you select `yes`, the script will not resolve incidents that have
+responders other than the user to be deleted. 
 
 ## Notes and Caveats
 

--- a/user_deprovision/user_deprovision.py
+++ b/user_deprovision/user_deprovision.py
@@ -124,10 +124,8 @@ class DeleteUser(APISession):
     def list_open_incidents(self, additional_params=None):
         """
         Get any open incidents assigned to the user.
-        
-        :param user_id:
-            The ID of the user.
-        :additional_params:
+
+        :param additional_params:
             Parameters to send to the list incidents index. One could specify
             ``'date_range': 'all'`` to get all incidents and not just those that
             are recent, for instance, or restrict to certain service IDs using
@@ -162,8 +160,7 @@ class DeleteUser(APISession):
     def escalation_policies(self):
         """List all escalation policies user is on"""
         if not hasattr(self, '_escalation_policies'):
-            self._escalation_policies = self.list_all('escalation_policies',
-                                                      params={'user_ids[]': self.user_id})
+            self._escalation_policies = self.list_all('escalation_policies', params={'user_ids[]': self.user_id})
         return self._escalation_policies
 
     def list_users_on_team(self, team_id):
@@ -181,8 +178,8 @@ class DeleteUser(APISession):
         """
         Remove a user or schedule from an escalation policy's rules.
 
-        :param escalation_rules:
-            The escalation policy's ``escalation_rules``
+        :param escalation_policy:
+            reference to the escalation policy to remove the user from
         :param obj:
             PagerDuty object or resource reference
         """

--- a/user_deprovision/user_deprovision.py
+++ b/user_deprovision/user_deprovision.py
@@ -183,7 +183,7 @@ class DeleteUser(APISession):
         :param obj:
             PagerDuty object or resource reference
         """
-        if obj == None:  # Assume it's the user we want to remove
+        if obj is None:  # Assume it's the user we want to remove
             obj = self.user
         obj_type = obj['type'].replace('_reference', '')
         new_rules = []

--- a/user_deprovision/user_deprovision.py
+++ b/user_deprovision/user_deprovision.py
@@ -440,7 +440,7 @@ def main(args):
             if not email:
                 continue
             email_list.append(email)
-    file.closed
+
     print("%d users to delete: %s" % (len(email_list), ', '.join(email_list)))
     # Prompt to fill in some gaps and confirm we want to continue:
     from_email = args.from_email

--- a/user_deprovision/user_deprovision.py
+++ b/user_deprovision/user_deprovision.py
@@ -319,7 +319,7 @@ def delete_user(access_token, user_email, from_email, prompt_del, auto_resolve, 
     # Incidents #
     #############
     log.info("Checking for incidents assigned to user %s...", user_id)
-    # Check for open incidents user is currently in use foro
+    # Check for open incidents user is currently in use for
     incidents = user_deleter.list_open_incidents()
     n_incidents = len(incidents)
     if n_incidents > 0:

--- a/user_deprovision/user_deprovision.py
+++ b/user_deprovision/user_deprovision.py
@@ -179,17 +179,13 @@ class DeleteUser(APISession):
             List of incident-like dict objects, i.e. retrieved from the API
         """
         for incident in incidents:
-            if len(incident.get('assignments')) > 1:
-                log.info('Resolving %s', incident['id'])
-                try:
-                    self.rput(incident['self'],
-                              json={'type': 'incident_reference', 'status': 'resolved'})
-                except PDClientError as e:
-                    handle_exception(e)
-                    log.error("Could not resolve incident %s.", incident['id'])
-            else:
-                log.info('Not resolving incident {}, as there are {} other responders'.format(
-                    incident.get('id'), len(incident.get('assignments'))))
+            log.info('Resolving %s', incident['id'])
+            try:
+                self.rput(incident['self'],
+                          json={'type': 'incident_reference', 'status': 'resolved'})
+            except PDClientError as e:
+                handle_exception(e)
+                log.error("Could not resolve incident %s.", incident['id'])
 
     @property
     def escalation_policies(self):

--- a/user_deprovision/user_deprovision.py
+++ b/user_deprovision/user_deprovision.py
@@ -296,7 +296,7 @@ def delete_user(access_token, user_email, from_email, prompt_del, auto_resolve,
         # Determine if we want to auto-resolve them
         autores = auto_resolve or input_yn("There are currently %d open "
                                            "incidents that this user is assigned. Do you want to auto-resolve "
-                                           "them? (y/n): " % n_incidents)
+                                           "them?" % n_incidents)
         if autores:
             log.info('Resolving all open incidents...')
             user_deleter.resolve_incidents(incidents)

--- a/user_deprovision/user_deprovision.py
+++ b/user_deprovision/user_deprovision.py
@@ -198,10 +198,6 @@ class DeleteUser(APISession):
             self._escalation_policies = self.list_all('escalation_policies', params={'user_ids[]': self.user_id})
         return self._escalation_policies
 
-    def list_users_on_team(self, team_id):
-        """List all users on a particular team"""
-        return self.list_all('users', params={'team_ids[]': team_id})
-
     def schedule_has_user(self, schedule):
         """Check if a schedule contains a particular user"""
         for user in schedule.get('users', []):

--- a/user_deprovision/user_deprovision.py
+++ b/user_deprovision/user_deprovision.py
@@ -431,9 +431,9 @@ def delete_user(access_token, user_email, from_email, prompt_del, auto_resolve,
         return 0
 
 
-def main(args):
+def main(arguments):
     email_list = []
-    with open(args.user_csv) as file:
+    with open(arguments.user_csv) as file:
         for (i, row) in enumerate(csv.reader(file)):
             email = row[0].strip()
             # Skip blank emails 
@@ -443,8 +443,8 @@ def main(args):
 
     print("%d users to delete: %s" % (len(email_list), ', '.join(email_list)))
     # Prompt to fill in some gaps and confirm we want to continue:
-    from_email = args.from_email
-    if not args.from_email:
+    from_email = arguments.from_email
+    if not arguments.from_email:
         from_email = input(
             "Please enter email address of the requesting agent: "
         ).strip()
@@ -461,7 +461,7 @@ def main(args):
     fileh.setFormatter(file_formatter)
     log.addHandler(fileh)
     log.setLevel(logging.INFO)
-    if args.verbose:
+    if arguments.verbose:
         stderrh = logging.StreamHandler()
         stderrh.setFormatter(logging.Formatter(u"%(levelname)s: %(message)s"))
         log.addHandler(stderrh)
@@ -470,11 +470,11 @@ def main(args):
     # Do the deed:
     count = 0
     for email in email_list:
-        if args.prompt_del and not input_yn(
+        if arguments.prompt_del and not input_yn(
                 "Proceed with deletion of user (%s)" % email):
             continue
-        count += delete_user(args.access_token, email, from_email,
-                             args.prompt_del, args.auto_resolve, args.backup)
+        count += delete_user(arguments.access_token, email, from_email,
+                             arguments.prompt_del, arguments.auto_resolve, arguments.backup)
     log.info("%d user(s) out of %d specified have been deleted." % (
         count, len(email_list)
     ))

--- a/user_deprovision/user_deprovision.py
+++ b/user_deprovision/user_deprovision.py
@@ -55,7 +55,7 @@ def input_yn(message):
 
     Summary: Prompt a y/n question
     Attributes:
-        @param (prompt): question requiring y/n answer from user
+        @param message: question requiring y/n answer from user
     Returns: Boolean value of the user's answer
     """
     response = input(message + " (y/n): ").strip().lower()

--- a/user_deprovision/user_deprovision.py
+++ b/user_deprovision/user_deprovision.py
@@ -306,7 +306,7 @@ def delete_user(access_token, user_email, from_email, prompt_del, auto_resolve,
                          "user is assigned. Please resolve them and try again.",
                          n_incidents)
             log.info("The %s%d incidents assigned to this user are: ",
-                     "first " if len(n_incidents) > 20 else "", n_incidents)
+                     "first " if n_incidents > 20 else "", n_incidents)
             for i in incidents[:20]:
                 log.info(i['self'])
             return 0


### PR DESCRIPTION
**Link back to Jira ticket:** [DOGE-337](https://pagerduty.atlassian.net/browse/DOGE-337)

## Description

This pull request makes several changes to the user deprovision script. 

* PEP8 formatting
* Removes some unused and faulty logic
* Saves resource intensive API calls for future use
* No longer resolves incidents when deleting a user if there are additional responders besides the user being deleted. 

## Implementation

The original logic of the script retrieved all schedules, all users on each schedule, all teams, and all users on each team every time it went to delete a single user. If the script is to process a small amount of users on a small account, that would work okay. On a larger account this number of API calls quickly turns into a problem.

So instead of making those redundant API calls, we instantiate a `Resources` object in the `main()` function that subsequently gets passed around the script 

### Steps to test changes
* run against an account that has users that have open incidents, escalation policies, schedules, and teams.

## Documentation 
The readme has been updated. No additional documentation needs to be updated. 