### PR TITLE
DOGE-326: Explicitly list errors at the end of the import user script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 *.pyc
 *.DS_Store
 *.csv
+*.log
+.ruby-version
+Gemfile.lock
+.idea
+backup

--- a/import_users/README.md
+++ b/import_users/README.md
@@ -27,16 +27,18 @@ In this format:
 To execute the script, run:
 
 ```
-ruby import_users.rb -a API_KEY_HERE -f PATH_TO_FILE_HERE -e REQUESTER_EMAIL 
+ruby import_users.rb -a API_KEY_HERE -f PATH_TO_FILE_HERE -e REQUESTER_EMAIL
 ```
 
 ## Notes and Caveats
-Use --help to view all commandline options. There is an option (-t) that will create teams for you if they do not already exist. 
-Whitespace is bad. The only place where whitespace is permitted is between the first and last names. There cannot be whitespace anywhere else in the CSV.
+Use --help to view all commandline options. There is an option (-t) that will create teams for you if they do not already exist.
+Whitespace is bad. The only place where whitespace is permitted is between the first and last names and inside team names. There cannot be whitespace anywhere else in the CSV.
 If you'd like to skip fields, you need to supplement the empty fields with commas. For example, if I want to skip title, country code, and phone number, my line would look like this:
 ```
-Alex Thompson,alex.t@example.com.invalid,,,,Best-Team-Ever
+Alex Thompson,alex.t@example.com.invalid,,,,Best Team Ever
 ```
+
+Team names cannot contain the following characters: '\\', '/', '&', '<', '>' or non-printable characters.
 
 ### Each user will be sent an invitation email the moment that they are created
 

--- a/import_users/README.md
+++ b/import_users/README.md
@@ -30,6 +30,10 @@ To execute the script, run:
 ruby import_users.rb -a API_KEY_HERE -f PATH_TO_FILE_HERE -e REQUESTER_EMAIL
 ```
 
+## Errors
+
+Errors are printed to the terminal as they happen, and are also recorded in a log file named after the requester_email. The log file will tell you the HTTP status, the response body, and the attempted payload or query.
+
 ## Notes and Caveats
 Use --help to view all commandline options. There is an option (-t) that will create teams for you if they do not already exist.
 Whitespace is bad. The only place where whitespace is permitted is between the first and last names and inside team names. There cannot be whitespace anywhere else in the CSV.

--- a/import_users/import_users.rb
+++ b/import_users/import_users.rb
@@ -29,7 +29,10 @@ class PagerDutyAgent
     response = connection.get(path, query,
         { 'Authorization' => "Token token=#{token}",
           'Accept' => 'application/vnd.pagerduty+json;version=2'})
-    raise "Error: #{response.body}" unless response.success?
+    if !response.success?
+      $errors.push(response.body)
+      raise "Error: #{response.body}"
+    end
     JSON.parse(response.body)
   end
 
@@ -49,7 +52,7 @@ class PagerDutyAgent
 
     if !response.success?
       $errors.push(response.body)
-      raise "WOW Error: #{response.body}"
+      raise "Error: #{response.body}"
     end
 
     return JSON.parse(response.body)

--- a/import_users/import_users.rb
+++ b/import_users/import_users.rb
@@ -47,9 +47,9 @@ class PagerDutyAgent
     end
     response = connection.post(path, body_json, headers)
 
-    if !response.success
-      raise "Error: #{response.body}"
+    if !response.success?
       $errors.push(response.body)
+      raise "WOW Error: #{response.body}"
     end
 
     return JSON.parse(response.body)
@@ -60,9 +60,9 @@ class PagerDutyAgent
       { 'Authorization' => "Token token=#{token}",
         'Accept' => 'application/vnd.pagerduty+json;version=2'})
 
-    if !response.success
-      raise "Error: #{response.body}"
+    if !response.success?
       $errors.push(response.body)
+      raise "Error: #{response.body}"
     end
 
     puts response.status
@@ -229,14 +229,6 @@ class CSVImporter
     CSV.foreach(csv_file) do |row|
       import_user(row_to_record(row))
     end
-
-    if $errors.length > 0
-      puts "\n\nERRORS FOUND:\n\n"
-      $errors.each do |error|
-        puts error
-      end
-    end
-
   end
 
   def row_to_record(row)
@@ -267,3 +259,10 @@ end.parse!
 agent = PagerDutyAgent.new(options[:access_token], options[:requester_email], options[:create_teams])
 
 CSVImporter.new(agent, options[:csv_path]).import
+
+if $errors.length > 0
+  puts "\n\nERRORS FOUND:\n\n"
+  $errors.each do |error|
+    puts error
+  end
+end

--- a/import_users/import_users.rb
+++ b/import_users/import_users.rb
@@ -12,7 +12,6 @@ class PagerDutyAgent
   attr_reader :requester_email
   attr_reader :create_teams
   attr_reader :connection
-  attr_reader :log
 
   def initialize(token, requester_email, create_teams)
     @log = Logger.new("import_errors_for_#{requester_email}.log")


### PR DESCRIPTION
**Link back to Jira ticket:** [DOGE-326](https://pagerduty.atlassian.net/browse/DOGE-326)

## Description

Currently if there are errors on running the import user script they get buried in a sea of output on the terminal. This change will output all the errors to a log file. 

## Implementation

Create a log file on script start. Every time there is an error, push the https status, the response body, and the payload to the log file. 

### Steps to test changes
* Run the script with bad data, see the errors in the log file but the good rows of the CSV still get users created for them .

## Documentation 
I also update the readme for other reasons, no documentation changes needed for this update. 