### PR TITLE
Isabella dev

### DIFF
--- a/get_info_on_all_users/get_users_by_role.py
+++ b/get_info_on_all_users/get_users_by_role.py
@@ -5,58 +5,86 @@ import pdpyras
 import sys
 import csv
 
- 
-
+# create a dictionary to keep track of how many people are in each role
+role_types_count = {}
 team_managers=[]
 
 def get_users(role, session):
+  role_types_count[role] = 0
+  if args.logging: 
     sys.stdout.write("Listing %ss:\n"%role)
-    members = [] 
-    with open('member_roles.csv', 'a+') as csvfile:
-      writer = csv.writer(csvfile)
-      writer.writerow(['Name', 'Role'])
-      for user in session.iter_all('users'): 
-        if user['role'] == role:
+  members = [] 
+  with open('member_roles.csv', 'a+') as csvfile:
+    writer = csv.writer(csvfile)
+    writer.writerow(['Name', 'Role'])
+    for user in session.iter_all('users'): 
+      if user['role'] == role:
+        role_types_count[role] += 1
+        if args.logging: 
           sys.stdout.write(user['name'] + "\n")
-          writer.writerow([user['name'], role])
-          members.append(user['name'])
-      total_for_role = str(len(members))   
+        writer.writerow([user['name'], role])
+        members.append(user['name'])
+    total_for_role = str(len(members))
+    if args.logging:   
       sys.stdout.write("Total number of "+role+"s: "+total_for_role)
       sys.stdout.write("\n-----\n")
 
+
 def get_managers(team_id, team_name, session):
-    with open('member_roles.csv', 'a+', newline='') as csvfile:
-      writer = csv.writer(csvfile) 
-      for member in session.iter_all('teams/%s/members'%team_id):
-        if member['role'] == 'manager':
+  with open('member_roles.csv', 'a+', newline='') as csvfile:
+    writer = csv.writer(csvfile)
+    for member in session.iter_all('teams/%s/members'%team_id):
+      if member['role'] == 'manager':
+        role_types_count['team managers'] += 1
+        if args.logging: 
           sys.stdout.write(member['user']['summary'] + "\n")
-          writer.writerow([member['user']['summary'], "Team Manager, " + team_name])
-          team_managers.append(member['user']['summary'])
+        writer.writerow([member['user']['summary'], "Team Manager, " + team_name])
+        team_managers.append(member['user']['summary'])
     
 
 def get_teams(session):
-    for team in session.iter_all('teams'):
-      team_name = (team['summary'])
-      get_managers(team['id'], team_name, session)
-    total_team_managers = str(len(team_managers))
+  role_types_count['team managers'] = 0 
+  for team in session.iter_all('teams'):
+    team_name = (team['summary'])
+    get_managers(team['id'], team_name, session)
+  total_team_managers = str(len(team_managers))
+  if args.logging: 
     sys.stdout.write("Total number of team managers: "+total_team_managers+"\n")
+    sys.stdout.write("\n-----\n")
     
 
 if __name__ == '__main__':
-    ap = argparse.ArgumentParser(description="Retrieves all users with the role(s) "
-        "stated in the command line argument")
-    ap.add_argument('-k', '--api-key', required=True, help="REST API key")
-    ap.add_argument('-r', '--roles', required=True, help="roles to be fetched", dest='roles')
-    args = ap.parse_args()
-    session = pdpyras.APISession(args.api_key)
-    roles = (args.roles).split(',')
-    for role in roles:
-      if role == "team_managers":
-        get_teams(session)
-      else:  
-        get_users(role, session)
+  ap = argparse.ArgumentParser(description="Retrieves all users with the role(s) "
+      "stated in the command line argument")
+  ap.add_argument('-k', '--api-key', required=True, help="REST API key")
+  ap.add_argument('-r', '--roles', required=True, help="roles to be fetched", dest='roles')
+  ap.add_argument('-v', '--logging', default=False, dest='logging', help="verbose logging", action='store_true')
+  args = ap.parse_args()
+  session = pdpyras.APISession(args.api_key)
+  roles = (args.roles).split(',')
+  for role in roles:
+    if role == "team_managers":
+      get_teams(session)
+    else:  
+      get_users(role, session)
+  for role_type, total in role_types_count.items():
+    sys.stdout.write(role_type+": "+str(total)+"\n")
+  with open('member_roles.csv', 'a+') as csvfile:
+    writer = csv.writer(csvfile)
+    writer.writerow([])
+    writer.writerow(["Role Type", "Total"])
+    for role_type, total in role_types_count.items():
+      writer.writerow([role_type, total])      
       
-
-
-
+# This script will take a comma separated list of roles as a command line argument and fetches all the users in an account that match one of 
+# roles provided in the list. Roles will be fetched in the order that they are provided in the command line argument. Running with -v flag will 
+# show which role is being retrieved and then list the members who match it. After retrieving all the members for a given role, a tally will be 
+# shown for how many users have that role. 
+# The script also creates a csv with names in the first column and users in the second. At the bottom of the CSV the totals for each role type
+# are listed.  
+# how to run:
+# python get_users_by_role.py -k API-KEY-HERE -r COMMA-SEPARATED-ROLES-LIST
 # acceptable values for roles: admin,read_only_user,read_only_limited_user,user,limited_user,observer,restricted_access,owner
+
+
+

--- a/get_info_on_all_users/get_users_by_role.py
+++ b/get_info_on_all_users/get_users_by_role.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+
+import argparse
+import pdpyras
+import sys
+
+# Get all users' contact methods.
+# Originally by Ryan Hoskin:
+# https://github.com/ryanhoskin/pagerduty_get_all_contact_methods
+
+users = []
+
+def get_users(session):
+    sys.stdout.write("Listing owner, global admins, and team managers:\n")
+    for user in session.iter_all('users'):
+      if user['role'] == 'admin' or user['role'] == 'owner':
+    #   sys.stdout.write("User: ")
+       users.append(user['name'])
+    #   sys.stdout.write("\n")
+
+def get_managers(team_id, session):
+    for member in session.iter_all('teams/%s/members'%team_id):
+     if member['role'] == 'manager':
+    #   sys.stdout.write("User: ")
+       users.append(member['user']['summary'])
+    #   sys.stdout.write("\n")
+
+def get_teams(session):
+    for team in session.iter_all('teams'):
+      get_managers(team['id'], session)
+  
+      #    sys.stdout.write("-----\n")
+
+def print_users():
+  set(users)
+  for user in users:
+    sys.stdout.write(user)
+    sys.stdout.write("\n")
+
+
+if __name__ == '__main__':
+    ap = argparse.ArgumentParser(description="Retrieves contact info for all "
+        "users in a PagerDuty account")
+    ap.add_argument('-k', '--api-key', required=True, help="REST API key")
+    args = ap.parse_args()
+    session = pdpyras.APISession(args.api_key)
+    get_users(session)
+    get_teams(session)
+    print_users()
+

--- a/get_info_on_all_users/get_users_by_role.py
+++ b/get_info_on_all_users/get_users_by_role.py
@@ -4,16 +4,12 @@ import argparse
 import pdpyras
 import sys
 
-# Get all users' contact methods.
-# Originally by Ryan Hoskin:
-# https://github.com/ryanhoskin/pagerduty_get_all_contact_methods
-
 users = []
 
-def get_users(session):
+def get_users(role, session):
     sys.stdout.write("Listing owner, global admins, and team managers:\n")
     for user in session.iter_all('users'):
-      if user['role'] == 'admin' or user['role'] == 'owner':
+      if user['role'] == role:
     #   sys.stdout.write("User: ")
        users.append(user['name'])
     #   sys.stdout.write("\n")
@@ -39,12 +35,19 @@ def print_users():
 
 
 if __name__ == '__main__':
-    ap = argparse.ArgumentParser(description="Retrieves contact info for all "
-        "users in a PagerDuty account")
+    ap = argparse.ArgumentParser(description="Retrieves all users with the role(s) "
+        "stated in the command line argument")
     ap.add_argument('-k', '--api-key', required=True, help="REST API key")
+    ap.add_argument('-t', '--team-managers', required=False, default=False, action='store_true', help="fetch team managers")
     args = ap.parse_args()
     session = pdpyras.APISession(args.api_key)
-    get_users(session)
-    get_teams(session)
+    roles = sys.argv[2:]
+    for role in roles:
+      get_users(role, session)
+
+    if args.team_managers:   
+      get_managers(session)
+      get_teams(session)
+      
     print_users()
 

--- a/get_info_on_all_users/get_users_by_role.py
+++ b/get_info_on_all_users/get_users_by_role.py
@@ -7,6 +7,7 @@ import csv
 
 # create a dictionary to keep track of how many people are in each role
 role_types_count = {}
+allowed_roles=['admin','read_only_user','read_only_limited_user','user','limited_user','observer','restricted_access','owner']
 team_managers=[]
 
 def get_users(role, session):
@@ -65,16 +66,23 @@ if __name__ == '__main__':
   for role in roles:
     if role == "team_managers":
       get_teams(session)
-    else:  
+    elif role in allowed_roles:  
       get_users(role, session)
+    else:  
+      sys.stdout.write("\n"+role+" is not an acceptable value. Please only use the following values with the -r flag:\n")
+      for api_value in allowed_roles:
+        sys.stdout.write(api_value+"\n")
+      sys.stdout.write("\n")  
   for role_type, total in role_types_count.items():
     sys.stdout.write(role_type+": "+str(total)+"\n")
-  with open('member_roles.csv', 'a+') as csvfile:
-    writer = csv.writer(csvfile)
-    writer.writerow([])
-    writer.writerow(["Role Type", "Total"])
-    for role_type, total in role_types_count.items():
-      writer.writerow([role_type, total])      
+
+# to write the totals for each role type at the bottom of the csv  
+  # with open('member_roles.csv', 'a+') as csvfile:
+  #   writer = csv.writer(csvfile)
+  #   writer.writerow([])
+  #   writer.writerow(["Role Type", "Total"])
+  #   for role_type, total in role_types_count.items():
+  #     writer.writerow([role_type, total])      
       
 # This script will take a comma separated list of roles as a command line argument and fetches all the users in an account that match one of 
 # roles provided in the list. Roles will be fetched in the order that they are provided in the command line argument. Running with -v flag will 
@@ -85,6 +93,3 @@ if __name__ == '__main__':
 # how to run:
 # python get_users_by_role.py -k API-KEY-HERE -r COMMA-SEPARATED-ROLES-LIST
 # acceptable values for roles: admin,read_only_user,read_only_limited_user,user,limited_user,observer,restricted_access,owner
-
-
-

--- a/get_info_on_all_users/get_users_by_role.py
+++ b/get_info_on_all_users/get_users_by_role.py
@@ -10,11 +10,11 @@ role_types_count = {}
 allowed_roles=['admin','read_only_user','read_only_limited_user','user','limited_user','observer','restricted_access','owner']
 team_managers=[]
 
-def write_rows(column1, column2):
+def write_rows(column1, column2, column3):
 # one function for writing to csv
   with open(filename, 'a+') as csvfile:
     writer = csv.writer(csvfile)
-    writer.writerow([column1, column2])
+    writer.writerow([column1, column2, column3])
 
 
 def get_users(role, session):
@@ -27,7 +27,7 @@ def get_users(role, session):
       role_types_count[role] += 1
       if args.logging: 
         sys.stdout.write(user['name'] + "\n")
-      write_rows(user['name'], role)
+      write_rows(user['name'], role, user['email'])
       members.append(user['name'])
   total_for_role = str(len(members))
   if args.logging:   
@@ -41,7 +41,9 @@ def get_managers(team_id, team_name, session):
       role_types_count['team managers'] += 1
       if args.logging: 
         sys.stdout.write(member['user']['summary'] + "\n")
-      write_rows([member['user']['summary'], "Team Manager, " + team_name])
+      user_id = member['user']['id']  
+      user = session.rget('/users/%s'%user_id)  
+      write_rows(user['name'], "Team Manager, " + team_name, user['email'])
       team_managers.append(member['user']['summary'])
     
 
@@ -71,14 +73,14 @@ if __name__ == '__main__':
     filename = args.filename + '.csv'
   else:
     filename = args.filename
-  write_rows('Name','Role')  
+  write_rows('Name','Role', 'Email')  
   for role in roles:
     if role == "team_managers":
       get_teams(session)
     elif role in allowed_roles:  
       get_users(role, session)
     else:  
-      sys.stdout.write("\n"+role+" is not an acceptable value. Please only use the following values with the -r flag:\n")
+      sys.stdout.write("\n"+role+" is not an acceptable value. Please only use the following values with the -r flag:\nteam_managers\n")
       for api_value in allowed_roles:
         sys.stdout.write(api_value+"\n")
       sys.stdout.write("\n")  

--- a/get_info_on_all_users/get_users_by_role.py
+++ b/get_info_on_all_users/get_users_by_role.py
@@ -11,6 +11,7 @@ allowed_roles=['admin','read_only_user','read_only_limited_user','user','limited
 team_managers=[]
 
 def write_rows(column1, column2):
+# one function for writing to csv
   with open(filename, 'a+') as csvfile:
     writer = csv.writer(csvfile)
     writer.writerow([column1, column2])
@@ -45,6 +46,7 @@ def get_managers(team_id, team_name, session):
     
 
 def get_teams(session):
+# first need to get all teams before we can look up team managers  
   role_types_count['team managers'] = 0 
   for team in session.iter_all('teams'):
     team_name = (team['summary'])
@@ -82,14 +84,7 @@ if __name__ == '__main__':
       sys.stdout.write("\n")  
   for role_type, total in role_types_count.items():
     sys.stdout.write(role_type+": "+str(total)+"\n")
-
-# to write the totals for each role type at the bottom of the csv  
-  # with open('member_roles.csv', 'a+') as csvfile:
-  #   writer = csv.writer(csvfile)
-  #   writer.writerow([])
-  #   writer.writerow(["Role Type", "Total"])
-  #   for role_type, total in role_types_count.items():
-  #     writer.writerow([role_type, total])      
+     
       
 # This script will take a comma separated list of roles as a command line argument and fetches all the users in an account that match one of 
 # roles provided in the list. Roles will be fetched in the order that they are provided in the command line argument. Running with -v flag will 

--- a/get_info_on_all_users/get_users_by_role.py
+++ b/get_info_on_all_users/get_users_by_role.py
@@ -95,5 +95,5 @@ if __name__ == '__main__':
 # The script also creates a csv with names in the first column and users in the second. At the bottom of the CSV the totals for each role type
 # are listed.  
 # how to run:
-# python get_users_by_role.py -k API-KEY-HERE -r COMMA-SEPARATED-ROLES-LIST
+# python get_users_by_role.py -k API-KEY-HERE -r COMMA-SEPARATED-ROLES-LIST -f FILENAME-FOR-CSV
 # acceptable values for roles: admin,read_only_user,read_only_limited_user,user,limited_user,observer,restricted_access,owner

--- a/get_info_on_all_users/get_users_by_role.py
+++ b/get_info_on_all_users/get_users_by_role.py
@@ -4,50 +4,48 @@ import argparse
 import pdpyras
 import sys
 
-users = []
+team_managers=[]
 
 def get_users(role, session):
-    sys.stdout.write("Listing owner, global admins, and team managers:\n")
-    for user in session.iter_all('users'):
+    sys.stdout.write("Listing %ss:\n"%role)
+    members = [] 
+    for user in session.iter_all('users'): 
       if user['role'] == role:
-    #   sys.stdout.write("User: ")
-       users.append(user['name'])
-    #   sys.stdout.write("\n")
+        sys.stdout.write(user['name'] + "\n")
+        members.append(user['name'])
+    total_for_role = str(len(members))   
+    sys.stdout.write("Total number of "+role+"s: "+total_for_role)
+    sys.stdout.write("\n-----\n")
 
-def get_managers(team_id, session):
+def get_managers(team_id, session): 
     for member in session.iter_all('teams/%s/members'%team_id):
      if member['role'] == 'manager':
-    #   sys.stdout.write("User: ")
-       users.append(member['user']['summary'])
-    #   sys.stdout.write("\n")
+       sys.stdout.write(member['user']['summary'] + "\n")
+       team_managers.append(member['user']['summary'])
+    
 
 def get_teams(session):
     for team in session.iter_all('teams'):
       get_managers(team['id'], session)
-  
-      #    sys.stdout.write("-----\n")
-
-def print_users():
-  set(users)
-  for user in users:
-    sys.stdout.write(user)
-    sys.stdout.write("\n")
-
+    total_team_managers = str(len(team_managers))
+    sys.stdout.write("Total number of team managers: "+total_team_managers+"\n")
+    
 
 if __name__ == '__main__':
     ap = argparse.ArgumentParser(description="Retrieves all users with the role(s) "
         "stated in the command line argument")
     ap.add_argument('-k', '--api-key', required=True, help="REST API key")
-    ap.add_argument('-t', '--team-managers', required=False, default=False, action='store_true', help="fetch team managers")
+    ap.add_argument('-r', '--roles', required=True, help="roles to be fetched", dest='roles')
     args = ap.parse_args()
     session = pdpyras.APISession(args.api_key)
-    roles = sys.argv[2:]
+    roles = (args.roles).split(',')
     for role in roles:
-      get_users(role, session)
-
-    if args.team_managers:   
-      get_managers(session)
-      get_teams(session)
+      if role == "team_managers":
+        get_teams(session)
+      else:  
+        get_users(role, session)
       
-    print_users()
 
+
+
+# acceptable values for roles: admin,read_only_user,read_only_limited_user,user,limited_user,observer,restricted_access,owner

--- a/get_info_on_all_users/get_users_by_role.py
+++ b/get_info_on_all_users/get_users_by_role.py
@@ -3,30 +3,41 @@
 import argparse
 import pdpyras
 import sys
+import csv
+
+ 
 
 team_managers=[]
 
 def get_users(role, session):
     sys.stdout.write("Listing %ss:\n"%role)
     members = [] 
-    for user in session.iter_all('users'): 
-      if user['role'] == role:
-        sys.stdout.write(user['name'] + "\n")
-        members.append(user['name'])
-    total_for_role = str(len(members))   
-    sys.stdout.write("Total number of "+role+"s: "+total_for_role)
-    sys.stdout.write("\n-----\n")
+    with open('member_roles.csv', 'a+') as csvfile:
+      writer = csv.writer(csvfile)
+      writer.writerow(['Name', 'Role'])
+      for user in session.iter_all('users'): 
+        if user['role'] == role:
+          sys.stdout.write(user['name'] + "\n")
+          writer.writerow([user['name'], role])
+          members.append(user['name'])
+      total_for_role = str(len(members))   
+      sys.stdout.write("Total number of "+role+"s: "+total_for_role)
+      sys.stdout.write("\n-----\n")
 
-def get_managers(team_id, session): 
-    for member in session.iter_all('teams/%s/members'%team_id):
-     if member['role'] == 'manager':
-       sys.stdout.write(member['user']['summary'] + "\n")
-       team_managers.append(member['user']['summary'])
+def get_managers(team_id, team_name, session):
+    with open('member_roles.csv', 'a+', newline='') as csvfile:
+      writer = csv.writer(csvfile) 
+      for member in session.iter_all('teams/%s/members'%team_id):
+        if member['role'] == 'manager':
+          sys.stdout.write(member['user']['summary'] + "\n")
+          writer.writerow([member['user']['summary'], "Team Manager, " + team_name])
+          team_managers.append(member['user']['summary'])
     
 
 def get_teams(session):
     for team in session.iter_all('teams'):
-      get_managers(team['id'], session)
+      team_name = (team['summary'])
+      get_managers(team['id'], team_name, session)
     total_team_managers = str(len(team_managers))
     sys.stdout.write("Total number of team managers: "+total_team_managers+"\n")
     


### PR DESCRIPTION
## Description
This script will take a comma separated list of roles as a command line argument and fetches all the users in an account that match one of roles provided in the list. Roles will be fetched in the order that they are provided in the command line argument. Running with -v flag will show which role is being retrieved and then list the members who match it. After retrieving all the members for a given role, a tally will be shown for how many users have that role. The script also creates a csv with names in the first column and users in the second. At the bottom of the CSV the totals for each role type are listed.  


## Implementation

`python get_users_by_role.py -k API-KEY-HERE -r COMMA-SEPARATED-ROLES-LIST`

acceptable values for roles: admin,read_only_user,read_only_limited_user,user,limited_user,observer,restricted_access,owner

