### PR TITLE
Add team roles

### DIFF
--- a/import_users/README.md
+++ b/import_users/README.md
@@ -26,7 +26,7 @@ In this format:
 
 ## Team Roles
 
-When a user is added to or associated with a team for the first time, their default team role will be dependent on their base role. Users can be added to a team manually or automatically by being added to an escalation policy that is associated with a team. Read more about team role (https://support.pagerduty.com/docs/advanced-permissions#section-roles-in-the-rest-api-and-saml)[here].
+When a user is added to or associated with a team for the first time, their default team role will be dependent on their base role. Users can be added to a team manually or automatically by being added to an escalation policy that is associated with a team. Read more about team role [here](https://support.pagerduty.com/docs/advanced-permissions#section-roles-in-the-rest-api-and-saml).
 
 | Base Role           | Default Team Role When Added to a Team |
 |---------------------|----------------------------------------|

--- a/import_users/README.md
+++ b/import_users/README.md
@@ -7,7 +7,7 @@
 To use this script, you must first have a CSV file ready formatted as follows:
 
 ```
-name,email,role,title,country_code,phone_number,teams
+name,email,role,title,country_code,phone_number,teams,team_roles
 ```
 
 In this format:
@@ -16,12 +16,32 @@ In this format:
   without country code
 - `teams` is a semicolon-delimited list of teams to which the given user should
   be added
+  - `team_roles` is a semicolon-delimited list of team roles to which the given team should
+    be added
 - `email` is the user's login address, and it must uniquely match the user.
 - `role` must be a valid user role value; see [Roles in the REST API and
   SAML](https://support.pagerduty.com/v1/docs/advanced-permissions#section-roles-in-the-rest-api-and-saml)
   in the PagerDuty Knowledge Base.
 - there must be **no spaces** between the commas and the items they separate  
 - do not include column headers
+
+## Team Roles
+
+- If no team roles are supplied the default team role of responder will be added to the team(s)
+- The order of the team should match the order of the team roles
+
+```
+..team1;team2,manager;observer
+```
+In the above example team1 will be set as manager and team2 will be set as observer etc
+
+- To apply the same team role for all teams you can define one team role
+
+```
+team1;team2;team3,observer
+```
+
+In the above example all the teams will be set as observers team role
 
 ## Input Format
 
@@ -43,7 +63,7 @@ ruby import_users.rb -a API_KEY_HERE -f PATH_TO_FILE_HERE -e REQUESTER_EMAIL
 Errors are printed to the terminal as they happen, and are also recorded in a log file named after the requester_email. The log file will tell you the HTTP status, the response body, and the attempted payload or query.
 
 ## Notes and Caveats
-Use --help to view all commandline options. 
+Use --help to view all commandline options.
 
 **Whitespace is bad**. The only place where whitespace is permitted is within fields: between the first and last names and inside team names and job titles. There cannot be whitespace anywhere else in the CSV.
 

--- a/import_users/README.md
+++ b/import_users/README.md
@@ -16,8 +16,7 @@ In this format:
   without country code
 - `teams` is a semicolon-delimited list of teams to which the given user should
   be added
-- `team_roles` is a semicolon-delimited list of team roles to which the given team should
-    be added
+- `team_roles` is a semicolon-delimited list of team roles that will be applied to the give team(s) in the order defined.
 - `email` is the user's login address, and it must uniquely match the user.
 - `role` must be a valid user role value; see [Roles in the REST API and
   SAML](https://support.pagerduty.com/v1/docs/advanced-permissions#section-roles-in-the-rest-api-and-saml)

--- a/import_users/README.md
+++ b/import_users/README.md
@@ -26,19 +26,18 @@ In this format:
 
 ## Team Roles
 
-When provisioning a user through the REST API or SAML, the user will by default be given the Manager (a.k.a. User) role, unless specified in the user's role property. The value set for it must be one of a set of fixed values that is recognized by our internal APIs, or our web services will respond with status 400 Invalid Request.
+When a user is added to or associated with a team for the first time, their default team role will be dependent on their base role. Users can be added to a team manually or automatically by being added to an escalation policy that is associated with a team. Read more about team role (https://support.pagerduty.com/docs/advanced-permissions#section-roles-in-the-rest-api-and-saml)[here].
 
-The values of the role field of user records, and also the permissions system, are as follows:
+| Base Role           | Default Team Role When Added to a Team |
+|---------------------|----------------------------------------|
+| Observer**          | Observer                               |
+| Stakeholder         | Observer                               |
+| Restricted Access** | Observer                               |
+| Responder**         | Responder                              |
+| Manager**           | Manager                                |
+| Global Admin        | Manager                                |
 
-| title               | value                  | flexible/fixed |
-|---------------------|------------------------|----------------|
-| Global Admin        | admin                  | Fixed          |
-| Full Stakeholder    | read_only_user         | Fixed          |
-| Limited Stakeholder | read_only_limited_user | Fixed          |
-| Manager / User      | user                   | Flexible       |
-| Responder           | limited_user           | Flexible       |
-| Observer            | observer               | Flexible       |
-| Restricted Access   | restricted_access      | Flexible       |
+** Users with flexible base roles (Restricted Access, Observer, Responder, Manager) can have their default team roles changed to grant them more more or less permissions on a specific team.
 
 - There are three team roles `manager`, `responder` and `observer`
 - A user with base role `owner` and `admin` will be applied a fixed team role of `manager`

--- a/import_users/README.md
+++ b/import_users/README.md
@@ -16,7 +16,7 @@ In this format:
   without country code
 - `teams` is a semicolon-delimited list of teams to which the given user should
   be added
-  - `team_roles` is a semicolon-delimited list of team roles to which the given team should
+- `team_roles` is a semicolon-delimited list of team roles to which the given team should
     be added
 - `email` is the user's login address, and it must uniquely match the user.
 - `role` must be a valid user role value; see [Roles in the REST API and
@@ -41,7 +41,7 @@ In the above example team1 will be set as manager and team2 will be set as obser
 team1;team2;team3,observer
 ```
 
-In the above example all the teams will be set as observers team role
+In the above example all the teams will be set as observer team role
 
 ## Input Format
 

--- a/import_users/README.md
+++ b/import_users/README.md
@@ -26,13 +26,26 @@ In this format:
 
 ## Team Roles
 
-- If no team roles are supplied the default team role of responder will be added to the team(s)
+| title               | value                  | flexible/fixed |
+|---------------------|------------------------|----------------|
+| Global Admin        | admin                  | Fixed          |
+| Full Stakeholder    | read_only_user         | Fixed          |
+| Limited Stakeholder | read_only_limited_user | Fixed          |
+| Manager / User      | user                   | Flexible       |
+| Responder           | limited_user           | Flexible       |
+| Observer            | observer               | Flexible       |
+| Restricted Access   | restricted_access      | Flexible       |
+
+- There are three team roles manager, responder and observer
+- A user with base role owner and admin will be applied a fixed team role of manager
+- A user with base role ready_only_user and ready_only_limited_user will be applied a fixed team role of observer
+- If no team roles are supplied the default team role will be added to the team(s) based on the user role
 - The order of the team should match the order of the team roles
 
 ```
 ..team1;team2,manager;observer
 ```
-In the above example team1 will be set as manager and team2 will be set as observer etc
+In the above example team1 will be set as manager and team2 will be set as observer respectively
 
 - To apply the same team role for all teams you can define one team role
 

--- a/import_users/README.md
+++ b/import_users/README.md
@@ -42,6 +42,14 @@ team1;team2;team3,observer
 
 In the above example all the teams will be set as observer team role
 
+- If you want the last team to have the team role as manager
+
+```
+...,team1;team2;team3,;;manager
+```
+
+In the above example the first two team roles are blank therefore responder team role will be applied and the last team will be set as manager
+
 ## Input Format
 
 To execute the script, run:

--- a/import_users/README.md
+++ b/import_users/README.md
@@ -26,6 +26,10 @@ In this format:
 
 ## Team Roles
 
+When provisioning a user through the REST API or SAML, the user will by default be given the Manager (a.k.a. User) role, unless specified in the user's role property. The value set for it must be one of a set of fixed values that is recognized by our internal APIs, or our web services will respond with status 400 Invalid Request.
+
+The values of the role field of user records, and also the permissions system, are as follows:
+
 | title               | value                  | flexible/fixed |
 |---------------------|------------------------|----------------|
 | Global Admin        | admin                  | Fixed          |
@@ -36,9 +40,9 @@ In this format:
 | Observer            | observer               | Flexible       |
 | Restricted Access   | restricted_access      | Flexible       |
 
-- There are three team roles manager, responder and observer
-- A user with base role owner and admin will be applied a fixed team role of manager
-- A user with base role ready_only_user and ready_only_limited_user will be applied a fixed team role of observer
+- There are three team roles `manager`, `responder` and `observer`
+- A user with base role `owner` and `admin` will be applied a fixed team role of `manager`
+- A user with base role `ready_only_user` and `ready_only_limited_user` will be applied a fixed team role of `observer`
 - If no team roles are supplied the default team role will be added to the team(s) based on the user role
 - The order of the team should match the order of the team roles
 

--- a/import_users/import_users.rb
+++ b/import_users/import_users.rb
@@ -224,7 +224,7 @@ class CSVImporter
         puts "Created team #{team} with ID #{team_id}, adding user to team."
         agent.add_user_to_team(team_id, user_id, team_role)
         puts "Added #{record.name} to #{team}, with role #{team_role}."
-        $log.info("Added #{record.name} to team #{team}.")
+        $log.info("Added #{record.name} to team #{team}, with role #{team_role}.")
       end
     end
 

--- a/import_users/import_users.rb
+++ b/import_users/import_users.rb
@@ -266,8 +266,12 @@ class CSVImporter
     # return first role if there is only one
     return team_roles[0] if team_roles.length == 1
 
+    role = team_roles[team_index] == '' ? 'responder' : team_roles[team_index]
+
+    puts team_index
+    puts role
     #return team role associated with the team OR return responder as default
-    team_roles[team_index] || 'responder'
+    return role
   end
 
 end

--- a/import_users/import_users.rb
+++ b/import_users/import_users.rb
@@ -269,7 +269,7 @@ class CSVImporter
     user_role = record.role
 
     #return observer as fixed role if base role is one of the ready_only
-    return 'observer' if user_role.include?('ready_only')
+    return 'observer' if user_role.include?('read_only')
 
     default_role = DEFAULT_TEAM_ROLES["#{user_role}".to_sym]
 

--- a/import_users/import_users.rb
+++ b/import_users/import_users.rb
@@ -261,11 +261,13 @@ class CSVImporter
   private
 
   def team_roles(record,team_index)
+    #role must be one of the following manager,observer,responder in the csv file as per our API
     team_roles = record.team_roles ? record.team_roles.split(";") : []
 
     # return first role if there is only one
     return team_roles[0] if team_roles.length == 1
 
+    #replace all the blank array elements with the default of 'responder'
     team_roles.map! { |r| r&.empty? ? 'responder' : r }
 
     #return team role associated with the team OR return responder as default

--- a/import_users/import_users.rb
+++ b/import_users/import_users.rb
@@ -207,12 +207,16 @@ class CSVImporter
     teams.each_with_index do |team,team_index|
       team_role = team_roles(record,team_index)
       team_id = agent.get_team_id(agent.find_teams_by_name(team.strip)["teams"], team.strip)
+      user_role = record.role.include?('ready_only')
+
       if team_id
-        agent.add_user_to_team(team_id, user_id, team_role)
-        puts "Added #{record.name} to team #{team}"
-        $log.info("Added #{record.name} to team #{team}")
-        puts "Role #{team_role} applied to #{team} team for #{record.name}"
-        $log.info("Role #{team_role} applied to #{team} team for #{record.name}")
+        if user_role ? team_role = 'observer' : team_role
+          agent.add_user_to_team(team_id, user_id, team_role)
+          puts "Added #{record.name} to team #{team}"
+          $log.info("Added #{record.name} to team #{team}")
+          puts "Role #{team_role} applied to #{team} team for #{record.name}"
+          $log.info("Role #{team_role} applied to #{team} team for #{record.name}")
+        end
       elsif agent.no_new_teams
         puts "Could not find team #{team}, skipping."
         $log.info("Could not find team #{team}, skipping.")
@@ -222,6 +226,7 @@ class CSVImporter
         r = agent.add_team(team.strip)
         team_id = r['team']['id']
         puts "Created team #{team} with ID #{team_id}, adding user to team."
+        user_role ? team_role = 'observer' : team_role
         agent.add_user_to_team(team_id, user_id, team_role)
         puts "Added #{record.name} to #{team}, with role #{team_role}."
         $log.info("Added #{record.name} to team #{team}, with role #{team_role}.")

--- a/import_users/import_users.rb
+++ b/import_users/import_users.rb
@@ -153,7 +153,7 @@ class CSVImporter
   Record = Struct.new(:name, :email, :role, :title, :country_code, :phone_number, :teams, :team_roles)
 
   DEFAULT_TEAM_ROLES = {'owner': 'manager','admin': 'manager','user': 'manager','limited_user': 'responder','ready_only_user': 'observer',
-                         'ready_only_limited_user': 'observer'}.freeze
+                         'ready_only_limited_user': 'observer', 'observer': 'observer'}.freeze
 
   attr_reader :agent
   attr_reader :csv_file

--- a/import_users/import_users.rb
+++ b/import_users/import_users.rb
@@ -152,6 +152,9 @@ class CSVImporter
 
   Record = Struct.new(:name, :email, :role, :title, :country_code, :phone_number, :teams, :team_roles)
 
+  DEFAULT_TEAM_ROLES = {'owner': 'manager','admin': 'manager','user': 'manager','limited_user': 'responder','ready_only_user': 'observer',
+                         'ready_only_limited_user': 'observer'}.freeze
+
   attr_reader :agent
   attr_reader :csv_file
 
@@ -207,16 +210,13 @@ class CSVImporter
     teams.each_with_index do |team,team_index|
       team_role = team_roles(record,team_index)
       team_id = agent.get_team_id(agent.find_teams_by_name(team.strip)["teams"], team.strip)
-      user_role = record.role.include?('ready_only')
 
       if team_id
-        if user_role ? team_role = 'observer' : team_role
-          agent.add_user_to_team(team_id, user_id, team_role)
-          puts "Added #{record.name} to team #{team}"
-          $log.info("Added #{record.name} to team #{team}")
-          puts "Role #{team_role} applied to #{team} team for #{record.name}"
-          $log.info("Role #{team_role} applied to #{team} team for #{record.name}")
-        end
+        agent.add_user_to_team(team_id, user_id, team_role)
+        puts "Added #{record.name} to team #{team}"
+        $log.info("Added #{record.name} to team #{team}")
+        puts "Role #{team_role} applied to #{team} team for #{record.name}"
+        $log.info("Role #{team_role} applied to #{team} team for #{record.name}")
       elsif agent.no_new_teams
         puts "Could not find team #{team}, skipping."
         $log.info("Could not find team #{team}, skipping.")
@@ -226,7 +226,6 @@ class CSVImporter
         r = agent.add_team(team.strip)
         team_id = r['team']['id']
         puts "Created team #{team} with ID #{team_id}, adding user to team."
-        user_role ? team_role = 'observer' : team_role
         agent.add_user_to_team(team_id, user_id, team_role)
         puts "Added #{record.name} to #{team}, with role #{team_role}."
         $log.info("Added #{record.name} to team #{team}, with role #{team_role}.")
@@ -267,16 +266,26 @@ class CSVImporter
 
   def team_roles(record,team_index)
     #role must be one of the following manager,observer,responder in the csv file as per our API
+    user_role = record.role
+
+    #return observer as fixed role if base role is one of the ready_only
+    return 'observer' if user_role.include?('ready_only')
+
+    default_role = DEFAULT_TEAM_ROLES["#{user_role}".to_sym]
+
+    #return manager as fixed role if base role is either admin or owner
+    return 'manager' if user_role == 'owner' || user_role == 'admin'
+
     team_roles = record.team_roles ? record.team_roles.split(";") : []
 
     # return first role if there is only one
     return team_roles[0] if team_roles.length == 1
 
-    #replace all the blank array elements with the default of 'responder'
-    team_roles.map! { |r| r&.empty? ? 'responder' : r }
+    #replace all the blank array elements with the default
+    team_roles.map! { |r| r&.empty? ? default_role : r }
 
-    #return team role associated with the team OR return responder as default
-    team_roles[team_index] || 'responder'
+    #return team role associated with the team OR return default team role
+    team_roles[team_index] || default_role
   end
 end
 

--- a/import_users/import_users.rb
+++ b/import_users/import_users.rb
@@ -266,14 +266,11 @@ class CSVImporter
     # return first role if there is only one
     return team_roles[0] if team_roles.length == 1
 
-    role = team_roles[team_index] == '' ? 'responder' : team_roles[team_index]
+    team_roles.map! { |r| r&.empty? ? 'responder' : r }
 
-    puts team_index
-    puts role
     #return team role associated with the team OR return responder as default
-    return role
+    team_roles[team_index] || 'responder'
   end
-
 end
 
 options = {}


### PR DESCRIPTION
**Link back to Jira ticket:**

Don't have a jira ticket for this more of a proactive work

## Description

Last week had a real use case where a user wanted to update/create new users and add them to a team and set team roles. 

The new changes have the ability to add team roles for the given team(s) in the csv. 

If no team roles are supplied in the csv the default team role as responder will be added (this is what was happening in the first instance). 

If only 3 teams are supplied and there are 2 team roles, the third one will be a responder (default) and so on.

If only one team role is supplied for 1 or more teams, all the teams will be set as the defined role. 

## Implementation


### Steps to test changes
* create a csv file with 1 team and 1 team_role
* create a csv file with 2 teams and 2 team_roles
* create a csv file with 3 teams and 3 team_roles
* create a csv file with 3 teams and 1 team_role
* create a csv file with 3 teams and 2 team_roles
* create a csv file with 3 team and no team role
* create a csv file with 3 teams, 1 of them being a new one (not existing) and 3 team_roles
* create a csv file with 3 teams, make the last team be the manager and the first two blank so the default of responder will be set
* create a csv file with 3 (or x team) teams, make the user a read_only_user or read_only_limited_user, define the teams and the script will set the team role to be observer for all the teams

## Documentation 
- [x] There is documentation that needs to be updated upon merging these changes

Links to any documentation to be updated: