### PR TITLE
Adds validation of the API key

### DIFF
--- a/import_users/import_users.rb
+++ b/import_users/import_users.rb
@@ -21,9 +21,23 @@ class PagerDutyAgent
                               :ssl => {:verify => true}) do |c|
       c.request  :url_encoded
       c.adapter  :net_http
+    end
+    #making an initial call to /users to extract subdomain corresponding to the API key
+    initial = connection.get("/users", query = {}, { 'Authorization' => "Token token=#{token}",
+          'Accept' => 'application/vnd.pagerduty+json;version=2'})
+    users = JSON.parse(initial.body)['users']
+    subdomain = users[0]['html_url'][/https:\/\/(.*)\.pagerduty\.com.*/, 1]
+    puts("About to perform user import for #{subdomain}, proceed? (y/n)")
+    #evaluating agent input
+    decision = ""
+    while decision.chomp != "y"
+      decision = gets
+      if decision.chomp == "n"
+      abort "Discontinuing user import"
+    end
+    end
     #logger defined as a global variable accessible to all classes in the script
     $log = Logger.new("import_errors_for_#{requester_email}.log")
-    end
   end
 
   def get(path, query = {})


### PR DESCRIPTION
Validate API key for user import script and provide an option to stop execution of the script.

**Link back to Jira ticket:** https://pagerduty.atlassian.net/browse/DOGE-380

## Description
As mentioned in the linked Jira, to prevent a scenario where users would be added to a different PagerDuty account, during initialization script will perform a check of the subdomain to which the entered API key belongs. 

## Implementation
Check for corresponding subdomain is made by performing a GET call to /users and accessing html_url property of the first user (emulated the same functionality of our pdpyras library)

### Steps to test changes
* Create a sample csv file
* Create an API key 
* Run script with the usual command `ruby import_users.rb -a u+4Ch4yrxC9uh9W3teHg -e test@pd.com -f ./test_load_observers.csv`
* Observe if the subdomain of the PagerDuty account is evaluated correctly
* Attempt proceeding with the import or discontinuing import, as well as invalid input options (e.g. "yes please")