### PR TITLE
add param to handle suppressed incidents

### DIFF
--- a/mass_update_incidents/mass_update_incidents.py
+++ b/mass_update_incidents/mass_update_incidents.py
@@ -14,6 +14,7 @@ import pdpyras
 # Default parameters:
 PARAMETERS = {
     'is_overview': 'true',
+    # 'with_suppressed' : 'true', #Uncomment to included Trigger (Suppressed) incidents
     # 'since': '', 
     # 'until': '',
     # 'time_zone': `UTC` 


### PR DESCRIPTION
**Link back to Jira ticket:**
https://pagerduty.atlassian.net/browse/ORCA-2344

https://pagerduty.slack.com/archives/CFMEAAR39/p1626366217205500?thread_ts=1626365505.205300&cid=CFMEAAR39

## Description
When running the mass resolve script, it skips all incidents that are in a suppressed state. Adding this param handles these use cases.

## Implementation

Un-comment line 17 'with_suppressed' to include suppressed incidents when querying incidents.

### Steps to test changes
* Create and incident a Triggered suppressed stated 
* Run the script; this incident will be skipped 
* uncomment the line this incident will now be  included  

## Documentation 
- [ ] There is documentation that needs to be updated upon merging these changes

Links to any documentation to be updated: