### PR TITLE
allow adding existing user to teams regardless of phone number

### DIFF
--- a/import_users/README.md
+++ b/import_users/README.md
@@ -118,13 +118,8 @@ bulk using a different automation.
 
 If the users corresponding to the email addresses already exist in the account,
 then they will be added to the teams specified in the last column of the input
-CSV, and moreover, contact methods will be added to them. However, if they
-already have contact methods matching the phone numbers, an error will be
-raised and the script will proceed to the next user without continuing work on
-that user (i.e. adding them to teams).
-
-If only adding users to a team, one can leave the phone number and phone
-country code columns blank.
+CSV, and contact methods will be added to them unless they
+already have contact methods matching the phone numbers given.
 
 #### The parser cannot gracefully handle unicode characters or Windows-style linebreaks
 

--- a/import_users/import_users.rb
+++ b/import_users/import_users.rb
@@ -206,16 +206,6 @@ class CSVImporter
       $log.info("Created a new user with ID #{user_id} and login email #{record.email}.")
     end
 
-    # Add user and email notification rule
-    ["SMS", "phone"].each do |type|
-      if (!record.phone_number || !record.country_code)
-        puts "Phone number and/or country code blank; skipping creation of #{type} contact method and notification rules."
-        $log.info("Phone number and/or country code blank; skipping creation of #{type} contact method and notification rules.")
-      else
-        add_contact_method(type, user_id, record)
-      end
-    end
-
     # Add user to teams
     puts "Adding user to teams."
     $log.info("Adding user #{record.name} to teams.")
@@ -243,6 +233,16 @@ class CSVImporter
         agent.add_user_to_team(team_id, user_id, team_role)
         puts "Added #{record.name} to #{team}, with role #{team_role}."
         $log.info("Added #{record.name} to team #{team}, with role #{team_role}.")
+      end
+    end
+
+    # Add user and email notification rule
+    ["SMS", "phone"].each do |type|
+      if (!record.phone_number || !record.country_code)
+        puts "Phone number and/or country code blank; skipping creation of #{type} contact method and notification rules."
+        $log.info("Phone number and/or country code blank; skipping creation of #{type} contact method and notification rules.")
+      else
+        add_contact_method(type, user_id, record)
       end
     end
 


### PR DESCRIPTION
**Link back to Jira ticket:**

## Description
This PR improves a suboptimality whereby if a user being imported already existed (with the given email) AND country code and phone number provided matched an existing contact method (or are otherwise invalid), the user would not be added to the desired teams.  

## Implementation
For the case of existing users, the phone number/country code is apt to throw an error before that user can be added to teams, so I just switched the order such that it adds the user to any designated teams (a very un-error-prone operation) before it attempts to add a phone number contact method.

### Steps to test changes
* Try importing a user with a new team name, a bogus country code and phone number, and an email that matches an existing user;  the existing user should be added to the new team.

## Documentation 
- [x] There is documentation that needs to be updated upon merging these changes

Links to any documentation to be updated:  https://pagerduty.atlassian.net/wiki/spaces/CS/pages/962888316/Import+Users