### PR TITLE
Adds checks for presence of commas in title property

### DIFF
--- a/import_users/import_users.rb
+++ b/import_users/import_users.rb
@@ -178,6 +178,21 @@ class CSVImporter
   end
 
   def import_user(record)
+  # verifying if country code value is either null or numeric string
+  # the contrary may suggest commas in user's title
+  unless (record.to_a[4].nil? || record.to_a[4].to_i != 0 || record.to_a[4] == " ")
+    puts("Title property for #{record.email} may include commas, proceed? y/n")
+    #evaluating agent input
+    decision = ""
+    while decision.chomp != "y"
+    decision = gets
+    if decision.chomp == "n"
+    $log.error("User#{record.email} was not imported due to title property misconfiguration")
+    abort "Discontinuing user import for #{record.email}"
+    end
+    end
+  end
+
     $log.info("Attempting to find existing user by email #{record.email}.")
     # Try to find an existing user
     users = agent.find_user_by_email(record.email)
@@ -200,20 +215,6 @@ class CSVImporter
       puts "Adding user: #{record.name}."
       $log.info("Attempting to add user #{record.name}.")
       $log.info("User's record details: #{record}.")
-      # verifying if country code value is either null or numeric string
-      # the contrary may suggest commas in user's title
-      unless (record.to_a[4].nil? || record.to_a[4].to_i != 0 || record.to_a[4] == " ")
-        puts("Title property for #{record.email} may include commas, proceed? y/n")
-        #evaluating agent input
-        decision = ""
-        while decision.chomp != "y"
-        decision = gets
-        if decision.chomp == "n"
-        $log.error("User#{record.email} was not imported due to title property misconfiguration")
-        abort "Discontinuing user import for #{record.email}"
-        end
-        end
-      end
       user = agent.add_user(record.name, record.email, record.role.downcase, record.title)
       user_id = user["user"]["id"]
       puts "Added user with ID #{user_id}."

--- a/import_users/import_users.rb
+++ b/import_users/import_users.rb
@@ -200,6 +200,20 @@ class CSVImporter
       puts "Adding user: #{record.name}."
       $log.info("Attempting to add user #{record.name}.")
       $log.info("User's record details: #{record}.")
+      # verifying if country code value is either null or numeric string
+      # the contrary may suggest commas in user's title
+      unless (record.to_a[4].nil? || record.to_a[4].to_i != 0 || record.to_a[4] == " ")
+        puts("Title property for #{record.email} may include commas, proceed? y/n")
+        #evaluating agent input
+        decision = ""
+        while decision.chomp != "y"
+        decision = gets
+        if decision.chomp == "n"
+        $log.error("User#{record.email} was not imported due to title property misconfiguration")
+        abort "Discontinuing user import for #{record.email}"
+        end
+        end
+      end
       user = agent.add_user(record.name, record.email, record.role.downcase, record.title)
       user_id = user["user"]["id"]
       puts "Added user with ID #{user_id}."
@@ -267,6 +281,7 @@ class CSVImporter
 
   def import
     CSV.foreach(csv_file) do |row|
+      $log.info(row)
       import_user(row_to_record(row))
     end
   end

--- a/import_users/import_users.rb
+++ b/import_users/import_users.rb
@@ -181,7 +181,7 @@ class CSVImporter
   # verifying if country code value is either null or numeric string
   # the contrary may suggest commas in user's title
   unless (record.to_a[4].nil? || record.to_a[4].to_i != 0 || record.to_a[4] == " ")
-    puts("Title property for #{record.email} may include commas, proceed? y/n")
+    puts("Title property for #{record.email} may include commas, proceed? (y/n)")
     #evaluating agent input
     decision = ""
     while decision.chomp != "y"


### PR DESCRIPTION
Adds checks for presence of commas in title property of each user in the provided csv

**Link back to Jira ticket:** NA

## Description

This PR accounts for the cases where an unnoticed comma may be present in the user's title. This will result in an incorrect processing of the particular record of the input file, as the title column in that case will be treated by the script as two columns, with the second one corresponding to the country code.  This will also shift all the subsequent columns, resulting in data loss and / or misconfiguration.

## Implementation

The PR uses `to_a` method of the Struct class in order to extract and check the 5th parameter for each CSV record. If it is a null, a space or a numeric string, the script proceeds with user import. Otherwise, the script will offer an option to abort or proceed with the import of the specific user record. The user import will not stop for subsequent users.

### Steps to test changes
* Create a csv file with several user records. 
* For one or more users, include comma in the title (e.g. `Operations, Engineer` instead of `Operations Engineer`
* Run the script as usual

## Documentation 
- [x] There is documentation that needs to be updated upon merging these changes

Links to any documentation to be updated: https://pagerduty.atlassian.net/wiki/spaces/CS/pages/159252846/How+to+complete+a+bulk+user+import; perhaps also https://support.pagerduty.com/docs/import-users-from-a-csv