### PR TITLE
Add schedule layer reorganizer script

### DIFF
--- a/schedule_layer_reorganizer/README.md
+++ b/schedule_layer_reorganizer/README.md
@@ -11,6 +11,6 @@ layers in the correct order for a PUT or POST request.
 
 ### Usage
 
-`python3 schedule_layer_reorganizer.py -k {API-KEY} -i {ID}`
+`python3 schedule_layer_reorganizer.py -k {API-KEY} -i {Schedule ID 1} {Schedule ID 2}`
 
 The script can be run on multiple schedules at once.

--- a/schedule_layer_reorganizer/README.md
+++ b/schedule_layer_reorganizer/README.md
@@ -1,0 +1,16 @@
+
+# Schedule Layer Reorganizer
+
+### Description
+This script GETs a list of schedules and saves them in unique files named after
+their schedule IDs, with schedule layers reversed.
+
+GET requests for schedules show schedule layers in reverse order to PUT and POST requests,
+so this script allows a user to easily GET the schedule and automatically put the schedule
+layers in the correct order for a PUT or POST request.
+
+### Usage
+
+`python3 schedule_layer_reorganizer.py -k {API-KEY} -i {ID}`
+
+The script can be run on multiple schedules at once.

--- a/schedule_layer_reorganizer/requirements.txt
+++ b/schedule_layer_reorganizer/requirements.txt
@@ -1,0 +1,5 @@
+certifi==2021.5.30
+charset-normalizer==2.0.6
+idna==3.2
+requests==2.26.0
+urllib3==1.26.7

--- a/schedule_layer_reorganizer/schedule_layer_reorganizer.py
+++ b/schedule_layer_reorganizer/schedule_layer_reorganizer.py
@@ -1,0 +1,59 @@
+import requests
+import argparse
+import json
+
+def set_headers(key):
+    ''' Set headers for API calls.'''
+    headers = {
+        'Content-Type': 'application/json',
+        'Accept': 'application/vnd.pagerduty+json;version=2',
+        'Authorization': f'Token token={key}'
+        }
+    return headers
+
+def get_schedule(headers,id):
+    ''' Get schedule and return the schedule with layers in reverse order.'''
+    url = f'https://api.pagerduty.com/schedules/{id}'
+    response = requests.get(url, headers=headers)
+    data = response.json()
+    print(f'Getting schedule {id}')
+    if response.status_code != 200:
+        print(response.status_code, data['error']['message'])
+        return None
+    print(f'Schedule {id} retrieved')
+    reversed_layers = []
+    layers = data['schedule']['schedule_layers']
+    for layer in layers:
+        reversed_layers.insert(0, layer)
+    data['schedule']['schedule_layers'] = reversed_layers
+    return json.dumps(data)
+
+def write_to_file(payload, id):
+    ''' Write schedule to file '''
+    with open(f'{id}.json', 'w') as f:
+        print('Writing to file')
+        f.write(payload)
+
+def main():
+    ap = argparse.ArgumentParser(
+        description='Get schedules and reverse the schedule layers for updating.'
+    )
+    ap.add_argument('-k',
+        '--key',
+        required=True,
+        help='REST API key'
+    )
+    ap.add_argument('-i',
+        '--ids',
+        required=True,
+        nargs='+',
+        help='Schedule IDs'
+    )
+    args = ap.parse_args()
+    for id in args.ids:
+        payload = get_schedule(set_headers(args.key), id)
+        if payload is not None:
+            write_to_file(payload, id)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Description

A script that can be used as a tool to more easily update schedules that have multiple layers on them. Currently, a GET request and a POST or PUT request for a schedule will have schedule layers in opposite order. This tool GETs a schedule and saves it to a file with the layers reversed so that the payload can easily be sent as a PUT or POST request without reversing the order of the schedule layers.

## Implementation
GET a schedule
Iterate through the schedule layers of the schedule and save to a list in reversed order
Replace the existing list with the reversed list in the schedule object
Write the JSON to a file


### Steps to test changes
* Run the GET on a multi-layered schedule
* Copy the response and send it as a PUT request
* No changes to the schedule should occur 

## Documentation 
- [] There is documentation that needs to be updated upon merging these changes

Links to any documentation to be updated: