### PR TITLE
[T2D2-31] Suppress pagination warnings in contact_methods.py

### DIFF
--- a/get_info_on_all_users/contact_methods.py
+++ b/get_info_on_all_users/contact_methods.py
@@ -6,7 +6,7 @@ import sys
 
 # Disables noisy warning logging from pdpyras
 import logging
-logging.disable(logging.WARNING);
+logging.disable(logging.WARNING)
 
 # Get all users' contact methods.
 # Originally by Ryan Hoskin:

--- a/get_info_on_all_users/contact_methods.py
+++ b/get_info_on_all_users/contact_methods.py
@@ -4,6 +4,10 @@ import argparse
 import pdpyras
 import sys
 
+# Disables noisy warning logging from pdpyras
+import logging
+logging.disable(logging.WARNING);
+
 # Get all users' contact methods.
 # Originally by Ryan Hoskin:
 # https://github.com/ryanhoskin/pagerduty_get_all_contact_methods


### PR DESCRIPTION
**Link back to Jira ticket:** [T2D2-31](https://pagerduty.atlassian.net/jira/software/c/projects/T2D2/issues/T2D2-31)

## Description

Changes were made to pdpyras three months ago that switched several logs from debug level to warning level. Because of that, when running the script to get all contact methods for an account, a warning is printed after every single user’s name. This fixes that by suppressing warnings.

## Implementation
Disable logging for WARNING level and below.

### Steps to test changes
* Run contact_methods.py on Master vs this branch to see the difference
