### PR TITLE
[T2D2-43] Clean up notifications_team_report folder

### DIFF
--- a/notifications_team_report/README.md
+++ b/notifications_team_report/README.md
@@ -1,0 +1,31 @@
+# Notifications by Team Report
+
+Generates notification reports for each team. A work-around for how notification reports in analytics cannot yet provide a per-team drilldown nor generate the report according to the team lens.
+
+As a note, if you have a Digital Operations account or if you've already purchased access to the *PagerDuty Analytics* product, you may find what you need in the **Team Health** report within the "Insights" portion of PD Labs:
+
+https://support.pagerduty.com/docs/pd-labs#team-health
+
+This python script will generate reports for each team on the account, as well as totals for the account.  
+
+
+## Input Format
+
+Running the script requires the provision of only one argument: a global REST API key (read-only is fine).
+
+To execute the script, run this with your key and email:
+
+```
+./notifications_team_report.py -k API_KEY_HERE 
+```
+
+Several other options are available below, but are not required.
+
+## Options
+
+- `-k`/`--api-key`: _(required)_ REST API key (should be a global key)
+- `-i`/`--interval`: _(optional)_ The number of days back in history over which to generate the report. (Default: 30)
+- `-v`/`--verbose`: _(optional)_ Turn on debug level logging and progress reporting.
+- `-w`/`--write-file`: _(optional)_ A file which will be used to cache data from the API prior to reporting. Helpful for large datasets.
+- `-r`/`--resume-file`: _(optional)_ Read data from this previously cached file instead of the API.
+

--- a/notifications_team_report/notifications_team_report.py
+++ b/notifications_team_report/notifications_team_report.py
@@ -49,16 +49,11 @@ def main():
     ap.add_argument('-k', '--api-key', type=str, required=True, 
         dest='api_key', help="REST API key")
     args = ap.parse_args()  
+   
     if args.verbose:
-        logging.basicConfig(
-            level='DEBUG',
-            stream=sys.stdout
-        )
+        logging.basicConfig(level='DEBUG',stream=sys.stdout)
     else: 
-        logging.basicConfig(
-            level='INFO',
-            stream=sys.stdout
-        )  
+        logging.basicConfig(level='INFO',stream=sys.stdout)
 
     now_s = int(time.time())
     if args.resume_file:

--- a/notifications_team_report/notifications_team_report.py
+++ b/notifications_team_report/notifications_team_report.py
@@ -46,8 +46,8 @@ def main():
         data that can be resumed from, before generating the reports. Useful\
         for if there's a massive quantity of ILE data to be saved, as a\
             safeguard in case something goes wrong in the reporting part.")
-    ap.add_argument('-t', '--token', type=str, help="A v2 REST API key to use\
-        for accessing notifications. A read-only key should suffice.")
+    ap.add_argument('-k', '--api-key', type=str, required=True, 
+        dest='api_key', help="REST API key")
     args = ap.parse_args()
     loglevs = ['info', 'critical', 'error', 'warning', 'info', 'debug']
     loglev = min(args.verbosity, 5)
@@ -60,7 +60,7 @@ def main():
     if args.resume_file:
         notifs, teams = pickle.load(args.resume_file)
     else:
-        api = pdpyras.APISession(args.token)
+        api = pdpyras.APISession(args.api_key)
 
         if 'teams' not in api.rget('/abilities'):
             logging.error("This account doesn't have the \"teams\" \ ability! "\

--- a/notifications_team_report/notifications_team_report.py
+++ b/notifications_team_report/notifications_team_report.py
@@ -39,8 +39,8 @@ def main():
     ap.add_argument('-r', '--resume-file', dest='resume_file', default=False,
         type=argparse.FileType('rb'), help="Read previous ILE data from this\
         file instead of retrieving it from the API.")
-    ap.add_argument('-v', dest='verbosity', action='count', default=0,
-        help="Logging verbosity (default: INFO-level messages).")
+    ap.add_argument('-v','--verbose', help="Verbose command line output (show progress)",
+        default=False, action='store_true'     )
     ap.add_argument('-w', '--write-file', dest='write_file', default=False,
         type=argparse.FileType('wb'), help="A cache file to use for saving ILE\
         data that can be resumed from, before generating the reports. Useful\
@@ -52,9 +52,14 @@ def main():
     loglevs = ['info', 'critical', 'error', 'warning', 'info', 'debug']
     loglev = min(args.verbosity, 5)
     logging.basicConfig(
-        level=[getattr(logging, l.upper()) for l in loglevs][loglev],
-        stream=sys.stdout
-    )
+            level='DEBUG',
+            stream=sys.stdout
+        )
+    else: 
+        logging.basicConfig(
+            level='INFO',
+            stream=sys.stdout
+        )  
 
     now_s = int(time.time())
     if args.resume_file:

--- a/notifications_team_report/notifications_team_report.py
+++ b/notifications_team_report/notifications_team_report.py
@@ -50,10 +50,11 @@ def main():
         dest='api_key', help="REST API key")
     args = ap.parse_args()  
    
-    if args.verbose:
-        logging.basicConfig(level='DEBUG',stream=sys.stdout)
-    else: 
-        logging.basicConfig(level='INFO',stream=sys.stdout)
+    loglev = 'DEBUG' if args.verbose else 'INFO'
+    logging.basicConfig(
+        level=loglev,
+        stream=sys.stdout
+    )
 
     now_s = int(time.time())
     if args.resume_file:

--- a/notifications_team_report/notifications_team_report.py
+++ b/notifications_team_report/notifications_team_report.py
@@ -19,7 +19,7 @@ def print_progress(result, i, n):
     new_percent = int(100.*i/n)
     prev_percent = int(100.*(i-1.)/n)
     if new_percent != prev_percent:
-        logging.info("Getting data: %d%% (%d of %d)", new_percent, i, n)
+        logging.debug("Getting data: %d%% (%d of %d)", new_percent, i, n)
 
 def main():
     # Memoizing dictionaries
@@ -48,10 +48,9 @@ def main():
             safeguard in case something goes wrong in the reporting part.")
     ap.add_argument('-k', '--api-key', type=str, required=True, 
         dest='api_key', help="REST API key")
-    args = ap.parse_args()
-    loglevs = ['info', 'critical', 'error', 'warning', 'info', 'debug']
-    loglev = min(args.verbosity, 5)
-    logging.basicConfig(
+    args = ap.parse_args()  
+    if args.verbose:
+        logging.basicConfig(
             level='DEBUG',
             stream=sys.stdout
         )


### PR DESCRIPTION
**Link back to Jira ticket:** [T2D2-43](https://pagerduty.atlassian.net/browse/T2D2-43)

## Description

This is a cleanup PR as part of T2D2-36 work. 

## Implementation

The main changes here are as follows:

- Adds a README file for the folder
- Switches `-t/--token` to `-k/--api-key` to match other scripts in this repo
- Makes the API key required in argparse instead of erroring at the pdpyras level
- Changes verbosity behavior from needing to enter `-v` five times to get debug level, to just either verbose or not
- Moves progress reporting to the verbose/debug logging

### Steps to test changes
* Pull down branch and run `./notifications_team_report.py` with no args: it will now error in argparse instead of pdpyras
* Run with valid key: it will run at INFO level logging with no progress reports
* Run with valid key and `-v` flag: It will run with progress reporting and debug logging

## Documentation 
- README added