### PR TITLE
INCIDENTS-129 add argument to request header

### DIFF
--- a/mass_update_incidents/mass_update_incidents.py
+++ b/mass_update_incidents/mass_update_incidents.py
@@ -23,6 +23,8 @@ PARAMETERS = {
 def mass_update_incidents(args):
     session = pdpyras.APISession(args.api_key,
         default_from=args.requester_email)
+    session.headers.update({"X-SOURCE-SCRIPT": "pupblic-support-scripts/mass_update_incidents"})
+
     if args.user_id:
         PARAMETERS['user_ids[]'] = args.user_id.split(',')
         print("Acting on incidents assigned to user(s): "+args.user_id)


### PR DESCRIPTION
**Link back to Jira ticket:**
https://pagerduty.atlassian.net/browse/INCIDENTS-129

## Description
this PR just adds an additional argument to the request header
`"X-SOURCE-SCRIPT": "pupblic-support-scripts/mass_update_incidents"`

A manual sleep/rate limit is not necessary since the pdpyras library has protection baked in.
https://pagerduty.github.io/pdpyras/#cooldown

## Implementation


### Steps to test changes
*

## Documentation 
- [x] There is documentation that needs to be updated upon merging these changes

Links to any documentation to be updated: