### PR TITLE
Fixes for various issues

### DIFF
--- a/maintenance_windows_bulk_operations/README.md
+++ b/maintenance_windows_bulk_operations/README.md
@@ -8,3 +8,25 @@ out.
 Both of these scripts, per their helptext, have a `-n/--dry-run` option that
 will allow you to see the changes that will be made without actually making
 those changes.
+
+
+#### Example usage `create_recurring_maintenance_window.py`:
+
+```
+python3 create_recurring_maintenance_windows.py \
+--api-key u+zZ0ozZ0ozZ0ozZ0oZz \
+--requester user@example.com \
+--service P000000 \
+--date 2022-07-02T04:00:00-0700 \
+--description "Scheduled weekly maintenance" \
+--duration 30 \
+--period 168 \
+--number 8
+```
+
+
+#### Example usage of `remove_all_future_maintenance_windows.py`:
+
+```
+python3 remove_all_future_maintenance_windows.py -k u+zZ0ozZ0ozZ0ozZ0oZz -s P000000
+```

--- a/maintenance_windows_bulk_operations/create_recurring_maintenance_windows.py
+++ b/maintenance_windows_bulk_operations/create_recurring_maintenance_windows.py
@@ -6,7 +6,7 @@ import argparse
 import pdpyras
 import sys
 import json
-import dateutil.parser as dateparser
+from dateutil import parser as dateparser
 from datetime import datetime, timedelta
 
 
@@ -16,9 +16,7 @@ def create_recurring_maintenance_windows(args):
     start_date = dateparser.parse(args.first_maint_window_date)
     end_date = dateparser.parse(args.first_maint_window_date) + \
         timedelta(minutes=args.duration_minutes)
-    for iter in range(1, args.num_repetitions, 1):
-        start_date = start_date + timedelta(hours=args.period_hours)
-        end_date = end_date + timedelta(hours=args.period_hours)
+    for iter in range(args.num_repetitions):
         print("Creating a %d-minute maintenance window starting %s."%(
             args.duration_minutes, start_date))
         if args.dry_run:
@@ -31,47 +29,63 @@ def create_recurring_maintenance_windows(args):
                 'description':args.description,
                 'services':[sref(s_id) for s_id in args.service_ids]
             })
+            start_date = start_date + timedelta(hours=args.period_hours)
+            end_date = end_date + timedelta(hours=args.period_hours)
         except pdpyras.PDClientError as e:
             msg = "API Error: "
             if e.response is not None:
                 msg += "HTTP %d: %s"%(e.response.status_code, e.response.text)
             print(msg)
-    print("(Note: no maintenance windows actually created because -n/--dry-run "
-        "was given)")
+    if args.dry_run:
+        print("(Note: no maintenance windows actually created because -n/--dry-run "
+            "was given)")
+
+
 def main():
     desc = "Create a series of recurring maintenance windows."
     ap = argparse.ArgumentParser(description=desc)
+
     ap.add_argument('-k', '--api-key', required=True, help="A REST API key")
+
     helptxt = "User login email address of the PagerDuty user to record as "\
         "the agent who created the maintenance window."
     ap.add_argument('-r', '--requester', required=True, help=helptxt)
+
     helptxt = "Service ID(s) for which to create the maintenance windows. "\
         "Note, this may be given multiple times to specify more than one "\
         "service."
     ap.add_argument('-s', '--service', default=[], action='append',
         dest='service_ids', help=helptxt, required=True)
+
     helptxt = "Date of the first maintenance window in the series. It must be "\
         "formatted as valid ISO8601, i.e. 2018-10-19T17:45:00-0700"
     ap.add_argument('-t', '--date', required=True,
         dest='first_maint_window_date', help=helptxt)
+
     helptxt = "Description of the maintenance window to create."
     ap.add_argument('-d', '--description', required=True, help=helptxt)
+
     helptxt = "Duration of the maintenance window in minutes"
     ap.add_argument('-l', '--duration', required=True, dest='duration_minutes',
         type=int, help=helptxt)
+
     helptxt = "Number of hours between the start of each successive "\
         "maintenance window"
     ap.add_argument('-p', '--period', required=True, dest='period_hours',
         type=int, help=helptxt)
+
     helptxt = "Total number of maintenance windows to create"
     ap.add_argument('-m', '--number', default=1, dest='num_repetitions',
         type=int, help=helptxt)
+
     ap.add_argument('-n', '--dry-run', default=False, action='store_true',
         help="Don't perform any action; instead, show the maintenance windows "
         "that would be created.")
+
     args = ap.parse_args()
 
     create_recurring_maintenance_windows(args)
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
**Link back to Jira ticket:**
https://pagerduty.atlassian.net/browse/T2D2-77

## Description
Issues fixed:

* One less maintenance window than specified would be created, regardless of number specified (e.g., if 7 specified, 6 would be created)
* The first maintenance window would have a start time not as indicated but rather start time indicated PLUS the period indicated
* dateutil package was not imported properly (for python 3.9)
* a "no maintenance windows actually created" message was printed to the console even when the MWs were created (and the --dry-run flag was not included)

I also made the args declarations more readable in the code and added examples to the README.

### Steps to test changes
* Try creating a few MWs with a variety of input data using the example in the README

## Documentation 
- [x] There is documentation that needs to be updated upon merging these changes

Links to any documentation to be updated:
Just the README.