### PR TITLE
verifying if API key exists or not

### DIFF
--- a/import_users/import_users.rb
+++ b/import_users/import_users.rb
@@ -25,6 +25,9 @@ class PagerDutyAgent
     #making an initial call to /users to extract subdomain corresponding to the API key
     initial = connection.get("/users", query = {}, { 'Authorization' => "Token token=#{token}",
           'Accept' => 'application/vnd.pagerduty+json;version=2'})
+    if !initial.success?
+        raise "Error: #{initial.status} Unauthorized"
+    end
     users = JSON.parse(initial.body)['users']
     subdomain = users[0]['html_url'][/https:\/\/(.*)\.pagerduty\.com.*/, 1]
     puts("About to perform user import for #{subdomain}, proceed? (y/n)")


### PR DESCRIPTION
**Link back to Jira ticket:**
https://pagerduty.atlassian.net/browse/T2D2-132

## Description

When making an initial connection and if the API key is incorrect, the error message returned was utterly misleading.

Added a check which will display an error message "401 Unauthorised" if an incorrect key is entered.