### PR TITLE
docs(dev): html escape display fix + minor changes

### DIFF
--- a/custom_field/README-DEV.md
+++ b/custom_field/README-DEV.md
@@ -18,7 +18,7 @@
     asdf local install ruby <version>
     ```
 - then check `ruby --version` to make sure ya got it
-  - please feel free to ask questions of your fellower T2ers -- environment setup is much easier in collaboration! :)
+  - please feel free to ask questions of your fellow supp. engineers -- environment setup is much easier in collaboration! :)
 
 ## API-Key Usage
 - The script and tests take the key as an environment variable.  You can pass that in two ways:
@@ -31,7 +31,7 @@
 ## Set-Up and Teardown
 ### Custom Field Cruft
 - This script does NOT delete custom fields.  It only adds them.  A buffer against well intentioned disruption of a production environment.
-  - Manual deletion can be done, with elaborated confirmation step, at: **https://<domain-name>.com/customfields/**
+  - Manual deletion can be done, with elaborated confirmation step, at: **https://\<your-domain\>.pagerduty.com/customfields/**
 - Set-Up: before any testing run you'll want to ensure that you don't *already* have custom field names matching those you're about to create.
 - Teardown: you'll need to clean up after testing the scripts (or just get an accumulation of oddly named custom fields)
 - Thanks as always to our testers!
@@ -44,11 +44,11 @@
 - Make a csv with whatever you want.  Please do *NOT* use the `rspec_test.csv` or `example.csv`.  But please *do* use them as a base to mutate.
   - `cp example.csv manual_test.csv; vim manual_test.csv` <-- Again, please mutate the files when testing.
 - Manual test: `bundle exec ruby import_custom_fields.rb --file manual_test.csv`
-- Check logs: `cat application.log`
-- Check your instance for changes: **https://<your-domain>.pagerduty.com/customfields/**
+- Check logs: `bat application.log` (or `cat` if you're oldschool)
+- Check your instance for changes: **https://\<your-domain\>.pagerduty.com/customfields/**
  
 
 ## Running `rspec` Tests
 - Run tests: `bundle exec rspec spec.rb`
-- Check your instance for changes: **https://<your-domain>.pagerduty.com/customfields/**
+- Check your instance for changes: **https://\<your-domain\>.pagerduty.com/customfields/**
   - note: only one custom field should be written (*not* the entire contents of `rspec_test.csv`)


### PR DESCRIPTION
"<your-domain>" was not rendering due to being treated as an html tag.  Made some minor text changes while I was in.

**Link back to Jira ticket:**

## Description
Minor README-DEV change

## Implementation
n/a

### Steps to test changes
n/a

## Documentation 
- [x] There is documentation that needs to be updated upon merging these changes

Links to any documentation to be updated:
n/a