### PR TITLE
change iter_all to rget 

### DIFF
--- a/get_info_on_all_users/contact_methods.py
+++ b/get_info_on_all_users/contact_methods.py
@@ -32,7 +32,7 @@ def print_contact_methods(user, session, csv):
         'email': None,
         'push': None,
     }
-    for contact_method in session.iter_all('users/%s/contact_methods'%user['id']):
+    for contact_method in session.rget('users/%s/contact_methods'%user['id']):
         if 'phone' in contact_method['type']:
             contacts['phone'] = '%s %s'%(contact_method['country_code'], contact_method['address'])
         elif 'sms' in contact_method['type']:


### PR DESCRIPTION
## Description

The `users/{id}/contact_methods` endpoint was being requested via the "iter_all" method, however, there is no expected "more" field in the contact_methods response and pagination does not exist and is not required for that endpoint. This results in a warning message upon running the script.

## Implementation

Change iter_all method to the rget method for the call to the `users/{id}/contact_methods` endpoint.

### Steps to test changes
* test script with iter_all and rget methods to confirm
* also confirm that there is no case where iter_all needs to be used because the `users/{id}/contact_methods` endpoint does not support pagination and users can only have a maximum of [10 contact methods](https://support.pagerduty.com/docs/user-profile#add-a-phone-sms-or-email-contact-method) at this time.


## Documentation 
- N/A 