### PR TITLE
Fix: script no longer appends on new run

### DIFF
--- a/get_info_on_all_users/get_users_by_role.py
+++ b/get_info_on_all_users/get_users_by_role.py
@@ -10,9 +10,9 @@ role_types_count = {}
 allowed_roles=['admin','read_only_user','read_only_limited_user','user','limited_user','observer','restricted_access','owner']
 team_managers=[]
 
-def write_rows(column1, column2, column3):
+def write_rows(column1, column2, column3, mode='a+'):
 # one function for writing to csv
-  with open(filename, 'a+') as csvfile:
+  with open(filename, mode) as csvfile:
     writer = csv.writer(csvfile)
     writer.writerow([column1, column2, column3])
 
@@ -73,7 +73,7 @@ if __name__ == '__main__':
     filename = args.filename + '.csv'
   else:
     filename = args.filename
-  write_rows('Name','Role', 'Email')  
+  write_rows('Name','Role', 'Email', mode='w')  
   for role in roles:
     if role == "team_managers":
       get_teams(session)


### PR DESCRIPTION
Previously the append flag was true reuslting in re-appending of CSV header and new content if command was re-run.

**Link back to Jira ticket:**
[T2D2-306](https://pagerduty.atlassian.net/jira/software/c/projects/T2D2/boards/662?quickFilter=3273&selectedIssue=T2D2-306)

## Description
script would append to existing files, including header - breaking at best syntax and possibly only semantics
[Bug report](https://github.com/PagerDuty/public-support-scripts/issues/115)

## Implementation
simply made writer mode a passed variable, with an append default

### Steps to test changes
* manual testing

## Documentation 
- no changes needed

Links to any documentation to be updated:

[T2D2-306]: https://pagerduty.atlassian.net/browse/T2D2-306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ