### PR TITLE
[BUGFIX] Mass update script: Avoid passing in incident ids via query parameter, which can cause 414 errors

### DIFF
--- a/mass_update_incidents/mass_update_incidents.py
+++ b/mass_update_incidents/mass_update_incidents.py
@@ -58,26 +58,27 @@ def mass_update_incidents(args):
         PARAMETERS["date_range"] = "all"
         print("Getting incidents of all time")
 
+    incident_ids_split = []
     if args.incident_id:
-        PARAMETERS["incident_ids[]"] = args.incident_id.split(",")
-        if len(PARAMETERS["incident_ids[]"]) > MAX_INCIDENTS:
+        incident_ids_split = args.incident_id.split(",")
+        if len(incident_ids_split) > MAX_INCIDENTS:
             raise ValueError(
-                f"You can only update a maximum of {MAX_INCIDENTS} incidents at a time. Received list of {len(PARAMETERS['incident_ids[]'])} incidents."
+                f"You can only update a maximum of {MAX_INCIDENTS} incidents at a time. Received list of {len(incident_ids_split)} incidents."
             )
     try:
         print("Parameters: " + str(PARAMETERS))
         script_start_time = time.time()
 
-        if args.incident_id:
+        if incident_ids_split:
             if args.action == "resolve":
                 # If resolving incidents, we need to fetch the incident details for the alert counts
                 # Fetch incident bodies in bulk using the bulk update endpoint
                 print(
-                    f"Fetching details for {len(PARAMETERS['incident_ids[]'])} incidents. Please be patient as this "
+                    f"Fetching details for {len(incident_ids_split)} incidents. Please be patient as this "
                     "can take a while for large volumes..."
                 )
                 incident_references = []
-                for incident_id in PARAMETERS["incident_ids[]"]:
+                for incident_id in incident_ids_split:
                     incident_references.append(
                         {"id": incident_id, "type": "incident_reference"}
                     )
@@ -101,7 +102,7 @@ def mass_update_incidents(args):
                 # For acknowledging, we don't need to fetch incident details
                 incidents = [
                     {"id": incident_id, "type": "incident_reference"}
-                    for incident_id in PARAMETERS["incident_ids[]"]
+                    for incident_id in incident_ids_split
                 ]
         else:
             print(


### PR DESCRIPTION
**Link back to Jira ticket:**
[INCIDENTS-2776](https://pagerduty.atlassian.net/browse/INCIDENTS-2776)

## Description
During some internal testing of the mass-update script to do bulk resolves, we found that the `i` / `incident-ids` flag can cause the script to fail with a 414 error:

```
<html>
<head><title>414 Request-URI Too Large</title></head>
<body>
<center><h1>414 Request-URI ...
<html>
<head><title>414 Request-URI Too Large</title></head>
<body>
<center><h1>414 Request-URI Too Large</h1></center>
<hr><center>nginx</center>
</body>
</html>
```

This was when passing in a large number of incidents (100+) into the `i` flag. The cause was that these incident ids were being appended as query parameters, which eventually created a URL that's too large for the server to handle.


## Implementation
Changed the setup steps that occur for the resolve action, to simply pass the parsed list of incident ids to the initial PUT request that's used to fetch incident details; rather than appending them to the global `PARAMETERS` value that's used to build the query parameters for subsequent API calls.

### Steps to test changes
* Run the mass update script with the resolve action, for a large number of incidents, eg: `python mass_update_incidents.py -k mysecretapikey -s myserviceid -a resolve -e "from_email" -i incidentid1,incidentid2,etc`

## Documentation 
~- [] There is documentation that needs to be updated upon merging these changes~

Links to any documentation to be updated:

[INCIDENTS-2776]: https://pagerduty.atlassian.net/browse/INCIDENTS-2776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ